### PR TITLE
Extract all sources script

### DIFF
--- a/content/1nephi/chapter_01.adoc
+++ b/content/1nephi/chapter_01.adoc
@@ -7,7 +7,7 @@ ____
 ____
 ...many men call it [highlight]#Nephi#.
 
-[small]#KJV Apocrypha, 1611, https://www.kingjamesbibleonline.org/2-Maccabees-Chapter-1/[2 Maccabees 1:36]#
+[small]#KJV Apocrypha, 1611, http://www.kingjamesbibleonline.org/2-Maccabees-Chapter-1/[2 Maccabees 1:36]#
 
 ____
 ____

--- a/content/1nephi/chapter_02.adoc
+++ b/content/1nephi/chapter_02.adoc
@@ -70,7 +70,7 @@ ____
 ____
 And I have [highlight]#filled him with the spirit# of God, in wisdom, and in understanding, and in knowledge
 
-[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Exodus-Chapter-32/[Exodus 31:3]#
+[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Exodus-Chapter-31/[Exodus 31:3]#
 
 ____
 {% endmargin %}

--- a/content/1nephi/chapter_04.adoc
+++ b/content/1nephi/chapter_04.adoc
@@ -27,7 +27,7 @@ ____
 
 ...that one man should die for the people, and that the whole nation perish not.
 
-[small]#KJV, 1769, http://www.kingjamesbibleonline.org/Jonh-Chapter-11/[John 11:50]#
+[small]#KJV, 1769, http://www.kingjamesbibleonline.org/John-Chapter-11/[John 11:50]#
 ____
 {% endmargin %}
 

--- a/content/1nephi/chapter_11.adoc
+++ b/content/1nephi/chapter_11.adoc
@@ -88,11 +88,13 @@ ____
 *1 Nephi 11:23* And he spake unto me, saying: Yea, and the most joyous to the soul.
 
 {% margin %}
+____
 The phrase "a going" is relatively uncommon in print from this period, but is also present in a letter written by Joseph Smith:
-____
+
 Mr. Stowell has a prospect of getting five or six hundred dollars he does not know certain that he can get it but he is a going to try and if he can get the money...
-____
+
 http://www.josephsmithpapers.org/paperSummary/letter-to-oliver-cowdery-22-october-1829[Letter to Oliver Cowdery, 22 October 1829]
+____
 {% endmargin %}
 
 *1 Nephi 11:24* And after that he had said these words, he said unto me: Look! And I looked and I beheld the Son of God [highlight]#a going# forth among the children of men. And I saw many fall down at his feet and worship him.

--- a/content/2nephi/chapter_09.adoc
+++ b/content/2nephi/chapter_09.adoc
@@ -7,9 +7,9 @@
 {% margin %}
 ____
 And though after my skin [highlight-orange]#worms destroy this body#, yet [highlight-orange]#in my flesh shall I see God#
-____
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Job-Chapter-19/[Job 19:26]#
+____
 
 {% endmargin %}
 
@@ -33,6 +33,7 @@ ____
 ...infinite atonement...
 
 [small]#https://books.google.com/books?id=YNo-AAAAYAAJ&pg=PA119&dq=%22infinite+atonement%22&hl=en&sa=X&ved=0ahUKEwi4sK3p1rDOAhUl7oMKHc9hBZ4Q6AEISjAI#v=onepage&q=%22infinite%20atonement%22&f=false[A Compendium of the System of Divine Truth by Jacob Catlin, Mass. 1824], and https://www.google.com/search?q=%22infinite+atonement%22&lr=lang_en&biw=956&bih=936&source=lnt&tbs=lr%3Alang_1en%2Ccdr%3A1%2Ccd_min%3A1%2F1%2F1800%2Ccd_max%3A12%2F31%2F1830&tbm=bks[many other pre-1830 sources]#
+____
 ____
 
 ...this corruptible must put on incorruption...

--- a/content/3nephi/chapter_07.adoc
+++ b/content/3nephi/chapter_07.adoc
@@ -82,8 +82,9 @@ ____
 ____
 
 Repent...for the remission of sins
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Acts-Chapter-2/[Acts 2:38]#
+____
 {% endmargin %}
 
 *3 Nephi 7:23* And it came to pass that thus passed away the thirty and second year also. And Nephi did cry unto the people in the commencement of the thirty and third year; and he did preach unto them [highlight-orange]#repentance and remission of sins.#

--- a/content/3nephi/chapter_08.adoc
+++ b/content/3nephi/chapter_08.adoc
@@ -43,8 +43,9 @@ ____
 ____
 
 ...and the rough ways shall be made smooth;
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Luke-Chapter-3/[Luke 3:5]#
+____
 {% endmargin %}
 
 *3 Nephi 8:13* And the highways were broken up, and the level roads were spoiled, and [highlight-orange]#many smooth places became rough.#

--- a/content/3nephi/chapter_09.adoc
+++ b/content/3nephi/chapter_09.adoc
@@ -93,8 +93,9 @@ ____
 ____
 
 He came unto his own, and his own received him not.
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-1/[John 1:11]#
+____
 {% endmargin %}
 
 *3 Nephi 9:16* [highlight-orange]#I came unto my own, and my own received me not;# and the scriptures concerning my coming are fulfilled.
@@ -103,9 +104,9 @@ ____
 ____
 
 But as many as received him, to them gave he power to become the sons of God, even to them that believe on his name
-____
-[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-1/[John 1:12]#
 
+[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-1/[John 1:12]#
+____
 {% endmargin %}
 
 *3 Nephi 9:17* [highlight-orange]#And as many as have received me, to them have I given to become the sons of God. And even so will I to as many as shall believe on my name.# For behold, by me redemption cometh, and in me is the law of Moses fulfilled.
@@ -114,13 +115,14 @@ ____
 ____
 
 ...I am the light of the world...
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-8/[John 8:12]#
 ____
-...I am Alpha and Omega, the beginning and the end, the first and the last.
 ____
-[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Revelation-Chapter-22/[Revelation 22:13]#
+...I am Alpha and Omega, the beginning and the end, the first and the last.
 
+[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Revelation-Chapter-22/[Revelation 22:13]#
+____
 {% endmargin %}
 
 *3 Nephi 9:18* [highlight-orange]#I am the light and the life of the world#. [highlight-orange]#I am Alpha and Omega, the beginning and the end.#
@@ -129,12 +131,14 @@ ____
 ____
 
 Above when he said, Sacrifice and offering and burnt offerings and offering for sin thou wouldest not, neither hadst pleasure therein; which are offered by the law;
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Hebrews-Chapter-10/[Hebrews 10:8]#
 ____
-For thou desirest not sacrifice...thou delightest not in burnt offering.
 ____
+For thou desirest not sacrifice...thou delightest not in burnt offering.
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Psalms-Chapter-51/[Psalms 51:16]#
+____
 {% endmargin %}
 
 *3 Nephi 9:19* And [highlight-orange]#ye shall offer up unto me no more the shedding of blood; yea, your sacrifices and your burnt offerings shall be done away#, for I will accept none of your sacrifices and your burnt offerings.
@@ -143,12 +147,14 @@ ____
 ____
 
 The sacrifices of God are a broken spirit: a broken and a contrite heart, O God, thou wilt not despise.
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Psalms-Chapter-51/[Psalms 51:17]#
 ____
-...he shall baptize you with the Holy Ghost, and with fire:...
 ____
+...he shall baptize you with the Holy Ghost, and with fire:...
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Matthew-Chapter-3/[Matthew 3:11]#
+____
 {% endmargin %}
 
 *3 Nephi 9:20* And [highlight]#ye shall offer for a sacrifice unto me a broken heart and a contrite spirit. And whoso cometh unto me with a broken heart and a contrite spirit#, [highlight-orange]#him will I baptize with fire and with the Holy Ghost#, even as the Lamanites because of their faith in me at the time of their conversion were baptized with fire and with the Holy Ghost--and they knew it not.
@@ -163,21 +169,26 @@ ____
 {% endmargin %}
 
 *3 Nephi 9:21* Behold, I have come into the world to bring redemption unto the world, [highlight-orange]#to save the world from sin.#
-____
+
 {% margin %}
 ____
 
 Suffer little [highlight]#children to come unto me#, and forbid them not: [highlight]#for of such is the kingdom of God.#
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Luke-Chapter-18/[Luke 18:16]#
+____
+____
 
 ...I lay down my life, that I might take it again.
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-10/[John 10:17]#
+____
+____
 
 Look unto me, and be ye saved, all the ends of the earth... 
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Isaiah-Chapter-45/[Isaiah 45:22]#
+____
 {% endmargin %}
 
 *3 Nephi 9:22* [highlight-orange]#Therefore whoso repenteth and cometh unto me as a little child, him will I receive, for of such is the kingdom of God#. Behold, for such [highlight-orange]#I have laid down my life and have taken it up again.# Therefore repent and [highlight]#come unto me, ye ends of the earth, and be saved.#

--- a/content/alma/chapter_05.adoc
+++ b/content/alma/chapter_05.adoc
@@ -155,11 +155,11 @@ ____
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-1/[John 1:29]#
 ____
+____
 
 ...believe on his name:
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/John-Chapter-1/[John 1:12]#
-
 ____
 {% endmargin %}
 

--- a/content/alma/chapter_07.adoc
+++ b/content/alma/chapter_07.adoc
@@ -128,7 +128,7 @@ ____
 ...now abideth faith, hope, charity...
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/1-Corinthians-Chapter-13/[I Corinthians 13:13]#
-
+____
 ____
 
 ...ye...may abound to every good work

--- a/content/alma/chapter_10.adoc
+++ b/content/alma/chapter_10.adoc
@@ -21,11 +21,13 @@ ____
 *Alma 10:7* As I was a journeying to see a very near kindred, behold, an angel of the Lord appeared unto me and said: Amulek, return to thine own house, for thou shalt feed a prophet of the Lord, yea, a holy man which art a chosen man of God; for he hath fasted many days because of the sins of this people, and he is an hungered. And thou shall receive him into thy house and feed him. And he shall bless thee and thy house, and the blessing of the Lord shall rest upon thee and thy house.
 
 {% margin %}
+____
 The phrase "a going" is relatively uncommon in print from this period, but is also present in a letter written by Joseph Smith:
-____
+
 Mr. Stowell has a prospect of getting five or six hundred dollars he does not know certain that he can get it but he is a going to try and if he can get the money...
-____
+
 http://www.josephsmithpapers.org/paperSummary/letter-to-oliver-cowdery-22-october-1829[Letter to Oliver Cowdery, 22 October 1829]
+____
 {% endmargin %}
 
 *Alma 10:8* And it came to pass that I obeyed the voice of the angel and returned towards my house. And as I was a going thither, I found the man which the angel said unto me thou shalt receive into thy house; and behold, it was this same man which hath been speaking unto you concerning the things of God.

--- a/content/alma/chapter_13.adoc
+++ b/content/alma/chapter_13.adoc
@@ -21,6 +21,7 @@ ____
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Hebrews-Chapter-5/[Hebrews 5:6]#
 ____
+____
 
 ...full of grace and truth.
 

--- a/content/alma/chapter_17.adoc
+++ b/content/alma/chapter_17.adoc
@@ -58,8 +58,9 @@ ____
 *Alma 17:25* But Ammon saith unto him: Nay, but I will be thy servant. Therefore Ammon became a servant to king Lamoni. And it came to pass that he was set among other servants to watch the flocks of Lamoni, according to the custom of the Lamanites.
 
 {% margin %}
-The phrase "a going" is relatively uncommon in print from this period, but is also present in a letter written by Joseph Smith:
 ____
+The phrase "a going" is relatively uncommon in print from this period, but is also present in a letter written by Joseph Smith:
+
 Mr. Stowell has a prospect of getting five or six hundred dollars he does not know certain that he can get it but he is a going to try and if he can get the money...
 
 http://www.josephsmithpapers.org/paperSummary/letter-to-oliver-cowdery-22-october-1829[Letter to Oliver Cowdery, 22 October 1829]

--- a/content/alma/chapter_30.adoc
+++ b/content/alma/chapter_30.adoc
@@ -112,8 +112,10 @@ Manahoee, their chief prophet, was smitten in the mouth, and slain, and two othe
 
 [small]#The Late War, 1816, https://wordtreefoundation.github.io/thelatewar/#false-prophets[35:29]#
 ____
+____
 
 See also Mormon Parallels, p. 731
+____
 {% endmargin %}
 
 *Alma 30:50* Now when Alma had said these words, [highlight]#Korihor was struck dumb, that he could not have utterance#, according to the words of Alma.

--- a/content/ether/chapter_04.adoc
+++ b/content/ether/chapter_04.adoc
@@ -64,7 +64,7 @@ ____
 He that believeth and is baptized shall be saved; but he that believeth not shall be damned.
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Mark-Chapter-16/[Mark 16:16]#
-____
+
 And these signs shall follow them that believe; In my name...
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Mark-Chapter-16/[Mark 16:17]#

--- a/content/ether/chapter_12.adoc
+++ b/content/ether/chapter_12.adoc
@@ -90,7 +90,7 @@ ____
 {% margin %}
 ____
 By faith the walls of Jericho fell down...
-____
+
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Hebrews-Chapter-11/[Hebrews 11:30]#
 ____
 ____

--- a/content/helaman/chapter_05.adoc
+++ b/content/helaman/chapter_05.adoc
@@ -91,8 +91,8 @@ ____
 
 *Helaman 5:26* And it came to pass that Nephi and Lehi did stand forth and began to speak unto them, saying: Fear not! For behold, it is God that hath shown unto you this marvelous thing, in the which is shewn unto you that ye cannot lay your hands on us to slay us.
 
-{% margin 5 %}
-____  
+{% margin %}
+____
 
 And suddenly there was a great earthquake, so that the foundations of the prison were shaken: and immediately all the doors were opened, and every one's bands were loosed.
 

--- a/content/helaman/chapter_10.adoc
+++ b/content/helaman/chapter_10.adoc
@@ -16,7 +16,6 @@ ____
 ...whatsoever thou shalt bind on earth shall be bound in heaven: and whatsoever thou shalt loose on earth shall be loosed in heaven.
 
 [small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Matthew-Chapter-16/[Matthew 16:19]#
-____
 
 Whatsoever ye shall bind on earth shall be bound in heaven: and whatsoever ye shall loose on earth shall be loosed in heaven.
 

--- a/content/mosiah/chapter_18.adoc
+++ b/content/mosiah/chapter_18.adoc
@@ -58,7 +58,7 @@ ____
 ____
 That their hearts might be comforted, being knit together in love...
 
-[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Collossians-Chapter-2/[Collossians 2:2]#
+[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Colossians-Chapter-2/[Colossians 2:2]#
 
 ____
 {% endmargin %}

--- a/content/mosiah/chapter_20.adoc
+++ b/content/mosiah/chapter_20.adoc
@@ -22,11 +22,10 @@ They hid themselves in the wilderness; they couched down as a lion; and as a you
 
 [small]#The Late War, 1817, https://wordtreefoundation.github.io/thelatewar/#entering-hearts[3:17]#
 ____
-
 ____
 The young lions roar after their prey, and seek their meat from God.
 
-King James Bible, https://www.kingjamesbibleonline.org/Psalms-104-21/[Psalm 104:21]
+[small]#King James Bible, http://www.kingjamesbibleonline.org/Psalms-104-21/[Psalm 104:21]#
 ____
 {% endmargin %}
 

--- a/content/mosiah/chapter_27.adoc
+++ b/content/mosiah/chapter_27.adoc
@@ -86,7 +86,7 @@ ____
 ____
 ...at the name of Jesus every knee should bow...And that every tongue should confess...
 
-[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Phillipians-Chapter-2/[Phillipians 2:10-11]#
+[small]#KJV Bible, 1769, http://www.kingjamesbibleonline.org/Philippians-Chapter-2/[Philippians 2:10-11]#
 
 ____
 {% endmargin %}

--- a/src/extract_sources.rb
+++ b/src/extract_sources.rb
@@ -4,14 +4,8 @@ require 'state_machine'
 
 Highlight = Struct.new(:color, :text)
 
-class Verse
+Verse = Struct.new(:book, :chapter, :verse, :text, :sources) do
   VERSE_RE = /\*([\w\s]+) (\d+):(\d+)\* (.*)/
-
-  attr_accessor :book, :chapter, :verse, :sources
-
-  def initialize(book, chapter, verse, text, sources)
-    @book, @chapter, @verse, @sources = book, chapter, verse, sources
-  end
 
   def self.from_line(line, sources)
     book, chapter, verse, text = line.match(VERSE_RE).captures
@@ -19,10 +13,8 @@ class Verse
   end
 end
 
-class Source
+Source = Struct.new(:text, :reference) do
   REFERENCES_START_WITH = '[small]#'
-
-  attr_accessor :text, :reference
 
   def self.from_lines(lines=[])
     lines.select! {|line| line.size > 0 }
@@ -35,16 +27,7 @@ class Source
       new(text, reference)
     end
   end
-  def initialize(text, reference)
-    @text, @reference = text, reference
-  end
 end
-
-#class Footnote
-#  def initialize(text)
-#    @text = text
-#  end
-#end
 
 Footnote = Struct.new(:text)
 
@@ -124,7 +107,7 @@ end
 
 if __FILE__ == $0
   if ARGV.size == 0
-    puts "usage: #{File.basename(__FILE__)} <file>.asc ..."
+    puts "usage: #{File.basename(__FILE__)} <file>.adoc ..."
     exit
   end
 
@@ -138,7 +121,8 @@ if __FILE__ == $0
     end
   end
   parser.verses.each do |verse|
-    puts verse.book + [verse.chapter, verse.verse].join(":")
-    p verse.sources
+    p verse
+    #puts verse.book + [verse.chapter, verse.verse].join(":")
+    #p verse.sources
   end
 end

--- a/src/extract_sources.rb
+++ b/src/extract_sources.rb
@@ -121,7 +121,12 @@ class Source < Struct.new(:text, :reference, :url, :bible_verse_details)
     super(*args)
     if self.reference
       # remove any ascii doc tag on the end of the url
-      self.url = URI.extract(self.reference).first.sub(/\[.*?\]\Z/, '')
+      self.url = URI.extract(self.reference).first.sub(/\[.*\]\Z/, '')
+      # The above regex works 99% of the time, but sometimes it doesn't clip
+      # off the first square bracket and first word.  It's a mystery to me
+      # because I've validated the regex online.  Until we figure out what is
+      # wrong, we'll do an additional substitution to remove the last bit:
+      self.url = self.url.sub(/\[\w+\Z/, '')
     end
   end
 

--- a/src/extract_sources.rb
+++ b/src/extract_sources.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env ruby
+
+require 'state_machine'
+
+Highlight = Struct.new(:color, :text)
+
+class Verse
+  VERSE_RE = /\*([\w\s]+) (\d+):(\d+)\* (.*)/
+
+  attr_accessor :book, :chapter, :verse, :sources
+
+  def initialize(book, chapter, verse, text, sources)
+    @book, @chapter, @verse, @sources = book, chapter, verse, sources
+  end
+
+  def self.from_line(line, sources)
+    book, chapter, verse, text = line.match(VERSE_RE).captures
+    new(book, chapter.to_i, verse.to_i, text, sources)
+  end
+end
+
+class Source
+  REFERENCES_START_WITH = '[small]#'
+
+  attr_accessor :text, :reference
+
+  def self.from_lines(lines=[])
+    lines.select! {|line| line.size > 0 }
+    if lines.size == 1 and !lines.first.start_with?(REFERENCES_START_WITH)
+      # it's a footnote
+      Footnote.new(lines[0])
+    else
+      text = lines[0...-1]
+      reference = lines.last
+      new(text, reference)
+    end
+  end
+  def initialize(text, reference)
+    @text, @reference = text, reference
+  end
+end
+
+#class Footnote
+#  def initialize(text)
+#    @text = text
+#  end
+#end
+
+Footnote = Struct.new(:text)
+
+class Parser
+  END_MARGIN = '{% endmargin %}'
+  START_MARGIN_RE = /{% margin( \d)? ?%}/
+  SOURCE_DELIMITER = "____"
+
+  attr_accessor :verses
+
+  def initialize
+    @verses = []
+    @source_lines = []
+    super()
+  end
+
+  state_machine :state, initial: :in_verses do
+    event :start_margin do
+      transition :in_verses => :in_margin
+    end
+
+    event :end_margin do
+      transition :in_margin => :in_verses
+    end
+
+    event :start_source do
+      transition :in_margin => :in_source
+    end
+
+    event :end_source do
+      transition :in_source => :in_margin
+    end
+
+    state :in_margin do
+      def parse(line)
+        if line == END_MARGIN
+          if @source_lines.size > 0
+            @sources << Source.from_lines(@source_lines)
+            @source_lines = []
+          end
+          end_margin
+        elsif line == SOURCE_DELIMITER
+          @source_lines = []
+          start_source
+        else
+          @source_lines << line
+        end
+      end
+    end
+
+    state :in_verses do
+      def parse(line)
+        if line =~ START_MARGIN_RE
+          @sources = []
+          start_margin
+        elsif line.size > 0
+          @verses << Verse.from_line(line, @sources || [])
+          @sources = []
+        end
+      end
+    end
+
+    state :in_source do
+      def parse(line)
+        if line == SOURCE_DELIMITER
+          @sources << Source.from_lines(@source_lines)
+          @source_lines = []
+          end_source
+        else
+          @source_lines << line
+        end
+      end
+    end
+  end
+end
+
+
+if __FILE__ == $0
+  if ARGV.size == 0
+    puts "usage: #{File.basename(__FILE__)} <file>.asc ..."
+    exit
+  end
+
+  parser = Parser.new
+
+  ARGV.each do |filename|
+    next if filename.include?("external")
+    IO.foreach(filename) do |line|
+      line.chomp!
+      parser.parse(line)
+    end
+  end
+  parser.verses.each do |verse|
+    puts verse.book + [verse.chapter, verse.verse].join(":")
+    p verse.sources
+  end
+end

--- a/src/extract_sources.rb
+++ b/src/extract_sources.rb
@@ -27,7 +27,7 @@ ScriptureVerse = Struct.new(:book, :chapter, :verse, :text, :sources) do
 end
 
 
-Source = Struct.new(:text, :reference, :href) do
+Source = Struct.new(:text, :reference, :url) do
   REFERENCES_START_WITH = '[small]#'
   REFERENCES_END_WITH = '#'
 
@@ -66,14 +66,14 @@ Source = Struct.new(:text, :reference, :href) do
 
   # A source with no reference is considered a 'footnote'
   def is_a_footnote?
-    self.reference.nil? && self.href.nil?
+    self.reference.nil? && self.url.nil?
   end
 
   def initialize(*args)
     super(*args)
     if self.reference
-      # remove any ascii doc tag on the end of the href
-      self.href = URI.extract(self.reference).first.sub(/\[.*?\]\Z/, '')
+      # remove any ascii doc tag on the end of the url
+      self.url = URI.extract(self.reference).first.sub(/\[.*?\]\Z/, '')
     end
   end
 


### PR DESCRIPTION
Script to extract all ascii doc file information into structured verses and sources that can be used programmatically.

Features:

* Uses a state machine to simplify parsing logic and make parsing highly efficient (so, requires state_machine gem)
* A "ScriptureVerse" has :book, :chapter, :verse, :text, and :sources attributes and a "Source" has :text and :reference attributes
* Outputs language agnostic YAML (e.g., will play nicely with python)
* Option to output YAML using ruby structs (if you'd rather work with dot notation rather than hashes).